### PR TITLE
Add Microsoft Defender variant of Outlook for Web URL

### DIFF
--- a/fix-outlook-hotkey-hijack.js
+++ b/fix-outlook-hotkey-hijack.js
@@ -8,6 +8,7 @@
 // @version        0.1.0
 // @run-at         document-start
 // @match          https://outlook.office.com/*
+// @match          https://outlook.office365.com.mcas.ms/mail/*
 // @grant          none
 // @license        MPL-2.0
 // ==/UserScript==


### PR DESCRIPTION
At first I added this via TamperMonkey's "User Matches" field in the Settings for this script, but it occurred to me that other users of the script may also be using the *.mcas.ms variant of Outlook in their organization, so I thought I'd submit a PR adding this.

For more info on this variant and others see https://learn.microsoft.com/en-us/defender-cloud-apps/troubleshooting-proxy-url.